### PR TITLE
Add copy to clipboard, update buy link to matcha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "14.1.3",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "react-hot-toast": "^2.4.1"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -1251,8 +1252,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -2337,6 +2337,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.14.tgz",
+      "integrity": "sha512-4UpC0NdGyAFqLNPnhCT2iHpza2q+RAY3GV85a/mRPdzyPQMsj0KmMMuetdIkzWRbJ+Hgau1EZztq8ImmiMGhsg==",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/gopd": {
@@ -3774,6 +3782,21 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.4.1.tgz",
+      "integrity": "sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==",
+      "dependencies": {
+        "goober": "^2.1.10"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -9,19 +9,20 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "next": "14.1.3",
     "react": "^18",
     "react-dom": "^18",
-    "next": "14.1.3"
+    "react-hot-toast": "^2.4.1"
   },
   "devDependencies": {
-    "typescript": "^5",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "autoprefixer": "^10.0.1",
+    "eslint": "^8",
+    "eslint-config-next": "14.1.3",
     "postcss": "^8",
     "tailwindcss": "^3.3.0",
-    "eslint": "^8",
-    "eslint-config-next": "14.1.3"
+    "typescript": "^5"
   }
 }

--- a/src/app/buy/page.tsx
+++ b/src/app/buy/page.tsx
@@ -2,5 +2,5 @@ import { redirect } from 'next/navigation'
 
 
 export default async function Swap() {
-  redirect('https://app.uniswap.org/swap?chain=base&inputCurrency=ETH&outputCurrency=0x0578d8A44db98B23BF096A382e016e29a5Ce0ffe')
+  redirect('https://matcha.xyz/tokens/base/0x0578d8a44db98b23bf096a382e016e29a5ce0ffe')
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,13 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import { Toaster } from "react-hot-toast";
 
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "higher",
-  description: "we're going higher.",
+  description: "we're going higher ↑",
 };
 
 export default function RootLayout({
@@ -16,7 +17,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        {children}
+        <Toaster />
+      </body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
+import Link from 'next/link'
+import Wordmark from './wordmark';
 
 const higherGreen = '#018A08'
-import Link from 'next/link'
 
 function animationDelay(i: number){
   const num = i + 2 // avoid 1 and 0
@@ -85,9 +86,7 @@ export default function Home() {
 
   return (
     <main className="flex min-h-screen min-w-screen flex-col items-center justify-center bg-[#018A08] text-white">
-      <div className="text-6xl font-medium z-10">
-        higher.
-      </div>
+      <Wordmark />
       <div className='text-gray-200 z-10'>
         a community of optimists on Base
       </div>

--- a/src/app/wordmark.tsx
+++ b/src/app/wordmark.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { toast } from "react-hot-toast";
+
+export default function Wordmark() {
+  return (
+    <div
+      onClick={() => {
+        navigator.clipboard.writeText("↑");
+        toast("Copied to clipboard!");
+      }}
+      className="group cursor-pointer text-6xl font-medium z-10 -ml-2.5"
+    >
+      <span className="inline-block group-hover:-translate-y-4 transition-transform duration-700 ease-in-out">
+        ↑
+      </span>
+      higher
+    </div>
+  );
+}


### PR DESCRIPTION
I got tired of having to search around for the "↑" character so I implemented the ability to copy it to the clipboard by clicking the wordmark

![ezgif-5-6d6dd7e298](https://github.com/anquetil/higher-party/assets/56174573/6f15a8a3-2657-4d52-94f6-d3fab1583003)

I also noticed the "buy" link did not seem friendly to new comers, so I updated it to Matcha which displays the image properly and doesn't warn you on first launch

![Screenshot 2024-04-10 143644](https://github.com/anquetil/higher-party/assets/56174573/c977710b-1ca5-409d-937d-975ed864f8d6)
![Screenshot 2024-04-10 143719](https://github.com/anquetil/higher-party/assets/56174573/8e5ee348-b5c4-4097-b565-2e115bfe01d4)